### PR TITLE
Fix controller re-injection when Instagram reuses DOM containers

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,3 +1,10 @@
+allowBuilds:
+  "@parcel/watcher": true
+  "@swc/core": true
+  esbuild: true
+  lmdb: true
+  msgpackr-extract: true
+  sharp: true
 onlyBuiltDependencies:
   - "@parcel/watcher"
   - "@swc/core"

--- a/src/modules/Injector.tsx
+++ b/src/modules/Injector.tsx
@@ -225,13 +225,29 @@ export default class Injector {
     }
 
     if (!mountParent) return
-    if (
-      mountParent instanceof Element &&
-      Array.from(mountParent.children).some((element) =>
-        element.hasAttribute("data-bigv-controller")
+
+    if (mountParent instanceof Element) {
+      const existingController = Array.from(mountParent.children).find(
+        (element) => element.hasAttribute("data-bigv-controller")
       )
-    )
-      return
+
+      if (existingController) {
+        const existingIndex = this.injectedList.findIndex(
+          (record) => record.controller === existingController
+        )
+        const existingRecord =
+          existingIndex !== -1 ? this.injectedList[existingIndex] : undefined
+
+        if (existingRecord?.video === video) return
+
+        if (existingRecord) {
+          this.injectedList.splice(existingIndex, 1)
+          this.dispose(existingRecord)
+        } else {
+          existingController.remove()
+        }
+      }
+    }
 
     this.beforeInject()
     this.clear()

--- a/src/modules/instagram/Stories.tsx
+++ b/src/modules/instagram/Stories.tsx
@@ -7,6 +7,7 @@ import {
   IG_STORIES_PROGRESS_BARS_INDICATOR,
   IG_STORIES_VOLUME_INDICATOR
 } from "~utils/constants"
+import { getActiveInstagramVideo } from "~utils/video"
 
 import IntervalInjector, {
   type IntervalInjectorOptions
@@ -29,6 +30,10 @@ export default class Stories extends IntervalInjector {
       ...options,
       variant: Variant.Stories
     })
+  }
+
+  protected shouldInjectVideo(video: HTMLVideoElement): boolean {
+    return getActiveInstagramVideo() === video
   }
 
   public injected(): void {


### PR DESCRIPTION
Updated Injector.tsx to correctly handle cases where Instagram reuses the same mountParent for a different video.

The injector now:

- Skips injection when the existing controller belongs to the same video.
- Disposes and removes the previous injection record when the controller belongs to a different video.
- Removes orphaned DOM controllers that have no corresponding InjectionRecord.
- Continues with the normal cleanup and injection flow afterward.

This prevents stale controllers from remaining attached when scrolling through virtualized Instagram feeds.